### PR TITLE
Fix the Withershadow Combine type

### DIFF
--- a/data/cryx.json
+++ b/data/cryx.json
@@ -616,7 +616,7 @@
         },
         {
           "id": "CU12",
-          "type": "unit",
+          "type": "unitCasterAttachment",
           "name": "The Withershadow Combine",
           "cost": 9,
           "fa": "C",


### PR DESCRIPTION
I believe the right type is `unitCasterAttachment`, see https://github.com/pumpi/troop-creator/blob/gh-pages/app/build/control/build.js#L299 for the relevant code.

Resolves #119.
